### PR TITLE
feat: 단어 슬라이드 모달

### DIFF
--- a/src/components/WordSlider/WordModal.jsx
+++ b/src/components/WordSlider/WordModal.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { EffectCards } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/effect-cards";
+import styles from "./WordSlider.module.css";
+import "./WordSliderGlobal.css";
+
+export default function WordModal({ word, onClose }) {
+  const wordList = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+  const initialIndex = wordList.indexOf(word);
+
+  const getColor = (word) => {
+    const colors = [
+      "#AFC2FF", "#9BB3FF", "#88A4FF", "#7495FF", "#6186FF",
+      "#1D44FF", "#3968FF", "#2659FF", "#124AFF",
+    ];
+    const index = parseInt(word) - 1;
+    return colors[index % colors.length];
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/80 flex justify-center items-center z-50">
+      <button
+        onClick={onClose}
+        className="absolute top-6 right-6 text-white text-2xl font-bold hover:text-gray-300 z-50"
+      >
+        ✖
+      </button>
+
+      <Swiper
+        effect="cards"
+        grabCursor={true}
+        initialSlide={initialIndex}
+        modules={[EffectCards]}
+        className={styles.mySwiper}
+      >
+        {wordList.map((w, idx) => (
+          <SwiperSlide key={idx}>
+            <div
+              className="w-full h-full flex items-center justify-center text-white text-3xl font-bold rounded-2xl"
+              style={{ backgroundColor: getColor(w) }}
+            >
+              {w}
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  );
+}

--- a/src/components/WordSlider/WordSlider.jsx
+++ b/src/components/WordSlider/WordSlider.jsx
@@ -1,3 +1,5 @@
+// WordSlider.jsx
+
 import React from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { EffectCards } from "swiper/modules";
@@ -6,7 +8,8 @@ import "swiper/css/effect-cards";
 import styles from "./WordSlider.module.css";
 import "./WordSliderGlobal.css";
 
-export default function WordSlider() {
+// ❗ props에서 onCardClick을 받아야 함
+export default function WordSlider({ onCardClick }) {
   return (
     <div className="word-slider">
       <Swiper
@@ -17,7 +20,10 @@ export default function WordSlider() {
       >
         {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((word, idx) => (
           <SwiperSlide key={idx}>
-            <div className="w-full h-full flex items-center justify-center">
+            <div
+              className="w-full h-full flex items-center justify-center cursor-pointer"
+              onClick={() => onCardClick(word)} // 이건 그대로 OK
+            >
               {word}
             </div>
           </SwiperSlide>
@@ -26,4 +32,3 @@ export default function WordSlider() {
     </div>
   );
 }
-

--- a/src/routes/main/MainPage.jsx
+++ b/src/routes/main/MainPage.jsx
@@ -1,9 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import MyStudySlider from "../../components/MyStudySlider/MyStudySlider";
 import WordSlider from "../../components/WordSlider/WordSlider";
+import WordModal from "../../components/WordSlider/WordModal"; // 모달 컴포넌트 import
 import UserApi from "../../api/userAPI";
 
 export default function MainPage() {
+  const [selectedWord, setSelectedWord] = useState(null);
+
   useEffect(() => {
     const fetchTest = async () => {
       try {
@@ -17,12 +20,19 @@ export default function MainPage() {
     fetchTest();
   }, []);
 
+  const handleCardClick = (word) => {
+    setSelectedWord(word);
+  };
+
+  const closeModal = () => {
+    setSelectedWord(null);
+  };
+
   return (
     <div className="min-h-screen bg-white dark:bg-zinc-800 text-black dark:text-white p-4 md:p-10 transition-all duration-300">
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-10">
-        {/* 좌측 영역 (3칸 차지) */}
+        {/* 좌측 영역 */}
         <div className="lg:col-span-3 flex flex-col gap-6">
-          {/* 유저 정보 카드 */}
           <div className="w-full h-60 aspect-[4/3] max-w-screen-sm mx-auto bg-white dark:bg-zinc-700 shadow rounded-4xl p-5 flex flex-col items-center justify-center">
             <img
               src="https://dh.aks.ac.kr/Edu/wiki/images/b/b7/%ED%95%91%EA%B5%AC.jpg"
@@ -35,24 +45,23 @@ export default function MainPage() {
             </p>
           </div>
 
-          {/* 내 스터디 카드 */}
           <MyStudySlider />
 
-          {/* 뉴스 포스팅 카드 >> 미구현 */}
           <div className="w-full aspect-[7/2] bg-white dark:bg-zinc-700 rounded-4xl shadow p-6">
             <p className="font-semibold text-lg">今日のニュース🔥</p>
           </div>
         </div>
 
-        {/* 우측 카드들 */}
+        {/* 우측 영역 */}
         <div className="flex flex-col gap-6">
-          <WordSlider />
+          <WordSlider onCardClick={handleCardClick} />
 
           <div className="w-full aspect-[7/6] max-w-md mx-auto bg-white dark:bg-zinc-700 rounded-4xl shadow" />
-
           <div className="w-full aspect-[5/4] max-w-md mx-auto bg-white dark:bg-zinc-700 rounded-4xl shadow" />
         </div>
       </div>
+
+      {selectedWord && <WordModal word={selectedWord} onClose={closeModal} />}
     </div>
   );
 }


### PR DESCRIPTION
메인페이지의 단어 슬라이드 모달 구현했습니다

## 🔖 PR 타입

- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🌿 반영 브랜치

main

## ⚒️ 구현 사항

메인페이지에서 우측 상단의 단어카드 클릭 시, 모달이 뜨도록 구현했습니다.
색상을 css에서 불러오면 충돌 일어날까봐 그냥 색상 코드값을 집어넣었습니다.

## ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/384eb246-ee74-4e52-b544-7521b0c2a646)
